### PR TITLE
Draft -- ChatGPT Codex Test: Stub Aptos wiring for Solana example

### DIFF
--- a/examples/oft-solana/tasks/common/config.get.ts
+++ b/examples/oft-solana/tasks/common/config.get.ts
@@ -30,6 +30,7 @@ interface TaskArgs {
  * @param point {OmniPoint}
  */
 const isSolana = (point: OmniPoint) => endpointIdToChainType(point.eid) === ChainType.SOLANA
+const isEvm = (point: OmniPoint) => endpointIdToChainType(point.eid) === ChainType.EVM
 
 /**
  * Helper function to get the hardhat.config.ts network name for a given endpoint id, or use the convention of
@@ -63,9 +64,9 @@ const action: ActionType<TaskArgs> = async ({ logLevel = 'info', oappConfig }, h
     const evmSdkFactory = createOAppFactory(createConnectedContractFactory())
     const configs: Record<string, Record<string, unknown>> = {}
 
-    // Iterate over the graph of connections not from Solana
+    // Iterate over the graph of connections from EVM chains
     const tasks = graph.connections
-        .filter(({ vector: { from } }) => !isSolana(from))
+        .filter(({ vector: { from } }) => isEvm(from))
         .map(({ vector: { from, to } }) => async () => {
             const endpointV2Sdk = await (await evmSdkFactory(from)).getEndpointSDK()
 

--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -62,11 +62,48 @@ export const createSdkFactory = (
         connectionFactory
     )
 
+    const aptosSdkFactory = async (point: OmniPoint): Promise<IOApp> => {
+        if (endpointIdToChainType(point.eid) !== ChainType.APTOS) {
+            throw new Error(`Point is not Aptos: ${formatEid(point.eid)}`)
+        }
+
+        // Return a noop implementation so the hardhat runner does not error out
+        return {
+            point,
+            getOwner: async () => undefined,
+            hasOwner: async () => true,
+            setOwner: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+            getEndpointSDK: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+            getPeer: async () => undefined,
+            hasPeer: async () => true,
+            setPeer: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+            getDelegate: async () => undefined,
+            isDelegate: async () => false,
+            setDelegate: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+            getEnforcedOptions: async () => '0x',
+            setEnforcedOptions: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+            getCallerBpsCap: async () => undefined,
+            setCallerBpsCap: async () => {
+                throw new Error('Aptos SDK not implemented')
+            },
+        } as unknown as IOApp
+    }
+
     // We now "merge" the two SDK factories into one.
     //
     // We do this by using the firstFactory helper function that is provided by the devtools package.
     // This function will try to execute the factories one by one and return the first one that succeeds.
-    return firstFactory<[OmniPoint], IOApp>(evmSdkfactory, solanaSdkFactory)
+    return firstFactory<[OmniPoint], IOApp>(evmSdkfactory, solanaSdkFactory, aptosSdkFactory)
 }
 
 export const createSolanaSignerFactory = (


### PR DESCRIPTION
## Summary
- add Aptos stub sdk factory
- ignore Aptos chains when reading config

## Testing
- `npx turbo run lint`
- `npx turbo run test` *(fails: forge not found)*