### PR TITLE
Add send task to OFT examples

### DIFF
--- a/examples/mint-burn-oft-adapter/hardhat.config.ts
+++ b/examples/mint-burn-oft-adapter/hardhat.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 
 import 'hardhat-deploy'
 import 'hardhat-contract-sizer'
+import './tasks/index'
 import '@nomiclabs/hardhat-ethers'
 import '@layerzerolabs/toolbox-hardhat'
 import { HardhatUserConfig, HttpNetworkAccountsUserConfig } from 'hardhat/types'

--- a/examples/mint-burn-oft-adapter/tasks/evm/send.ts
+++ b/examples/mint-burn-oft-adapter/tasks/evm/send.ts
@@ -1,0 +1,56 @@
+import { BigNumber, utils } from 'ethers'
+import { task, types } from 'hardhat/config'
+import { ActionType, HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+const makeBytes32 = (bytes?: string): string => utils.hexZeroPad(bytes || '0x0', 32)
+
+const getLayerZeroScanLink = (hash: string, isTestnet = false) =>
+    isTestnet ? `https://testnet.layerzeroscan.com/tx/${hash}` : `https://layerzeroscan.com/tx/${hash}`
+
+interface TaskArguments {
+    dstEid: number
+    amount: string
+    to: string
+    contractName: string
+}
+
+const action: ActionType<TaskArguments> = async (
+    { dstEid, amount, to, contractName },
+    hre: HardhatRuntimeEnvironment
+) => {
+    const signer = await hre.ethers.getNamedSigner('deployer')
+    // @ts-expect-error ignore for example
+    const token = (await hre.ethers.getContract(contractName)).connect(signer)
+
+    const amountLD = BigNumber.from(amount)
+    const sendParam = {
+        dstEid,
+        to: makeBytes32(to),
+        amountLD: amountLD.toString(),
+        minAmountLD: amountLD.mul(9_000).div(10_000).toString(),
+        extraOptions: '0x',
+        composeMsg: '0x',
+        oftCmd: '0x',
+    }
+    const [msgFee] = await token.functions.quoteSend(sendParam, false)
+    const txResponse = await token.functions.send(sendParam, msgFee, signer.address, {
+        value: msgFee.nativeFee,
+        gasLimit: 500_000,
+    })
+    const txReceipt = await txResponse.wait()
+    console.log(`send: ${amount} to ${to}: ${txReceipt.transactionHash}`)
+    console.log(
+        `Track cross-chain transfer here: ${getLayerZeroScanLink(
+            txReceipt.transactionHash,
+            dstEid == EndpointId.SOLANA_V2_TESTNET
+        )}`
+    )
+}
+
+task('send', 'Sends a transaction', action)
+    .addParam('dstEid', 'Destination endpoint ID', undefined, types.int, false)
+    .addParam('amount', 'Amount to send in wei', undefined, types.string, false)
+    .addParam('to', 'Recipient address', undefined, types.string, false)
+    .addOptionalParam('contractName', 'Name of the contract in deployments folder', 'MyOFT', types.string)

--- a/examples/mint-burn-oft-adapter/tasks/index.ts
+++ b/examples/mint-burn-oft-adapter/tasks/index.ts
@@ -1,0 +1,1 @@
+import './evm/send'

--- a/examples/native-oft-adapter/hardhat.config.ts
+++ b/examples/native-oft-adapter/hardhat.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 
 import 'hardhat-deploy'
 import 'hardhat-contract-sizer'
+import './tasks/index'
 import '@nomiclabs/hardhat-ethers'
 import '@layerzerolabs/toolbox-hardhat'
 import { HardhatUserConfig, HttpNetworkAccountsUserConfig } from 'hardhat/types'

--- a/examples/native-oft-adapter/tasks/evm/send.ts
+++ b/examples/native-oft-adapter/tasks/evm/send.ts
@@ -1,0 +1,56 @@
+import { BigNumber, utils } from 'ethers'
+import { task, types } from 'hardhat/config'
+import { ActionType, HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+const makeBytes32 = (bytes?: string): string => utils.hexZeroPad(bytes || '0x0', 32)
+
+const getLayerZeroScanLink = (hash: string, isTestnet = false) =>
+    isTestnet ? `https://testnet.layerzeroscan.com/tx/${hash}` : `https://layerzeroscan.com/tx/${hash}`
+
+interface TaskArguments {
+    dstEid: number
+    amount: string
+    to: string
+    contractName: string
+}
+
+const action: ActionType<TaskArguments> = async (
+    { dstEid, amount, to, contractName },
+    hre: HardhatRuntimeEnvironment
+) => {
+    const signer = await hre.ethers.getNamedSigner('deployer')
+    // @ts-expect-error ignore for example
+    const token = (await hre.ethers.getContract(contractName)).connect(signer)
+
+    const amountLD = BigNumber.from(amount)
+    const sendParam = {
+        dstEid,
+        to: makeBytes32(to),
+        amountLD: amountLD.toString(),
+        minAmountLD: amountLD.mul(9_000).div(10_000).toString(),
+        extraOptions: '0x',
+        composeMsg: '0x',
+        oftCmd: '0x',
+    }
+    const [msgFee] = await token.functions.quoteSend(sendParam, false)
+    const txResponse = await token.functions.send(sendParam, msgFee, signer.address, {
+        value: msgFee.nativeFee,
+        gasLimit: 500_000,
+    })
+    const txReceipt = await txResponse.wait()
+    console.log(`send: ${amount} to ${to}: ${txReceipt.transactionHash}`)
+    console.log(
+        `Track cross-chain transfer here: ${getLayerZeroScanLink(
+            txReceipt.transactionHash,
+            dstEid == EndpointId.SOLANA_V2_TESTNET
+        )}`
+    )
+}
+
+task('send', 'Sends a transaction', action)
+    .addParam('dstEid', 'Destination endpoint ID', undefined, types.int, false)
+    .addParam('amount', 'Amount to send in wei', undefined, types.string, false)
+    .addParam('to', 'Recipient address', undefined, types.string, false)
+    .addOptionalParam('contractName', 'Name of the contract in deployments folder', 'MyOFT', types.string)

--- a/examples/native-oft-adapter/tasks/index.ts
+++ b/examples/native-oft-adapter/tasks/index.ts
@@ -1,0 +1,1 @@
+import './evm/send'

--- a/examples/oft-adapter/hardhat.config.ts
+++ b/examples/oft-adapter/hardhat.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 
 import 'hardhat-deploy'
 import 'hardhat-contract-sizer'
+import './tasks/index'
 import '@nomiclabs/hardhat-ethers'
 import '@layerzerolabs/toolbox-hardhat'
 import { HardhatUserConfig, HttpNetworkAccountsUserConfig } from 'hardhat/types'

--- a/examples/oft-adapter/tasks/evm/send.ts
+++ b/examples/oft-adapter/tasks/evm/send.ts
@@ -1,0 +1,56 @@
+import { BigNumber, utils } from 'ethers'
+import { task, types } from 'hardhat/config'
+import { ActionType, HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+const makeBytes32 = (bytes?: string): string => utils.hexZeroPad(bytes || '0x0', 32)
+
+const getLayerZeroScanLink = (hash: string, isTestnet = false) =>
+    isTestnet ? `https://testnet.layerzeroscan.com/tx/${hash}` : `https://layerzeroscan.com/tx/${hash}`
+
+interface TaskArguments {
+    dstEid: number
+    amount: string
+    to: string
+    contractName: string
+}
+
+const action: ActionType<TaskArguments> = async (
+    { dstEid, amount, to, contractName },
+    hre: HardhatRuntimeEnvironment
+) => {
+    const signer = await hre.ethers.getNamedSigner('deployer')
+    // @ts-expect-error ignore for example
+    const token = (await hre.ethers.getContract(contractName)).connect(signer)
+
+    const amountLD = BigNumber.from(amount)
+    const sendParam = {
+        dstEid,
+        to: makeBytes32(to),
+        amountLD: amountLD.toString(),
+        minAmountLD: amountLD.mul(9_000).div(10_000).toString(),
+        extraOptions: '0x',
+        composeMsg: '0x',
+        oftCmd: '0x',
+    }
+    const [msgFee] = await token.functions.quoteSend(sendParam, false)
+    const txResponse = await token.functions.send(sendParam, msgFee, signer.address, {
+        value: msgFee.nativeFee,
+        gasLimit: 500_000,
+    })
+    const txReceipt = await txResponse.wait()
+    console.log(`send: ${amount} to ${to}: ${txReceipt.transactionHash}`)
+    console.log(
+        `Track cross-chain transfer here: ${getLayerZeroScanLink(
+            txReceipt.transactionHash,
+            dstEid == EndpointId.SOLANA_V2_TESTNET
+        )}`
+    )
+}
+
+task('send', 'Sends a transaction', action)
+    .addParam('dstEid', 'Destination endpoint ID', undefined, types.int, false)
+    .addParam('amount', 'Amount to send in wei', undefined, types.string, false)
+    .addParam('to', 'Recipient address', undefined, types.string, false)
+    .addOptionalParam('contractName', 'Name of the contract in deployments folder', 'MyOFT', types.string)

--- a/examples/oft-adapter/tasks/index.ts
+++ b/examples/oft-adapter/tasks/index.ts
@@ -1,0 +1,1 @@
+import './evm/send'

--- a/examples/oft-upgradeable/hardhat.config.ts
+++ b/examples/oft-upgradeable/hardhat.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 
 import '@openzeppelin/hardhat-upgrades'
 import 'hardhat-deploy'
+import './tasks/index'
 import '@nomiclabs/hardhat-waffle'
 import 'hardhat-deploy-ethers'
 import 'hardhat-contract-sizer'

--- a/examples/oft-upgradeable/tasks/evm/send.ts
+++ b/examples/oft-upgradeable/tasks/evm/send.ts
@@ -1,0 +1,56 @@
+import { BigNumber, utils } from 'ethers'
+import { task, types } from 'hardhat/config'
+import { ActionType, HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+const makeBytes32 = (bytes?: string): string => utils.hexZeroPad(bytes || '0x0', 32)
+
+const getLayerZeroScanLink = (hash: string, isTestnet = false) =>
+    isTestnet ? `https://testnet.layerzeroscan.com/tx/${hash}` : `https://layerzeroscan.com/tx/${hash}`
+
+interface TaskArguments {
+    dstEid: number
+    amount: string
+    to: string
+    contractName: string
+}
+
+const action: ActionType<TaskArguments> = async (
+    { dstEid, amount, to, contractName },
+    hre: HardhatRuntimeEnvironment
+) => {
+    const signer = await hre.ethers.getNamedSigner('deployer')
+    // @ts-expect-error ignore for example
+    const token = (await hre.ethers.getContract(contractName)).connect(signer)
+
+    const amountLD = BigNumber.from(amount)
+    const sendParam = {
+        dstEid,
+        to: makeBytes32(to),
+        amountLD: amountLD.toString(),
+        minAmountLD: amountLD.mul(9_000).div(10_000).toString(),
+        extraOptions: '0x',
+        composeMsg: '0x',
+        oftCmd: '0x',
+    }
+    const [msgFee] = await token.functions.quoteSend(sendParam, false)
+    const txResponse = await token.functions.send(sendParam, msgFee, signer.address, {
+        value: msgFee.nativeFee,
+        gasLimit: 500_000,
+    })
+    const txReceipt = await txResponse.wait()
+    console.log(`send: ${amount} to ${to}: ${txReceipt.transactionHash}`)
+    console.log(
+        `Track cross-chain transfer here: ${getLayerZeroScanLink(
+            txReceipt.transactionHash,
+            dstEid == EndpointId.SOLANA_V2_TESTNET
+        )}`
+    )
+}
+
+task('send', 'Sends a transaction', action)
+    .addParam('dstEid', 'Destination endpoint ID', undefined, types.int, false)
+    .addParam('amount', 'Amount to send in wei', undefined, types.string, false)
+    .addParam('to', 'Recipient address', undefined, types.string, false)
+    .addOptionalParam('contractName', 'Name of the contract in deployments folder', 'MyOFT', types.string)

--- a/examples/oft-upgradeable/tasks/index.ts
+++ b/examples/oft-upgradeable/tasks/index.ts
@@ -1,0 +1,1 @@
+import './evm/send'

--- a/examples/oft/hardhat.config.ts
+++ b/examples/oft/hardhat.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 
 import 'hardhat-deploy'
 import 'hardhat-contract-sizer'
+import './tasks/index'
 import '@nomiclabs/hardhat-ethers'
 import '@layerzerolabs/toolbox-hardhat'
 import { HardhatUserConfig, HttpNetworkAccountsUserConfig } from 'hardhat/types'

--- a/examples/oft/tasks/evm/send.ts
+++ b/examples/oft/tasks/evm/send.ts
@@ -1,0 +1,56 @@
+import { BigNumber, utils } from 'ethers'
+import { task, types } from 'hardhat/config'
+import { ActionType, HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+const makeBytes32 = (bytes?: string): string => utils.hexZeroPad(bytes || '0x0', 32)
+
+const getLayerZeroScanLink = (hash: string, isTestnet = false) =>
+    isTestnet ? `https://testnet.layerzeroscan.com/tx/${hash}` : `https://layerzeroscan.com/tx/${hash}`
+
+interface TaskArguments {
+    dstEid: number
+    amount: string
+    to: string
+    contractName: string
+}
+
+const action: ActionType<TaskArguments> = async (
+    { dstEid, amount, to, contractName },
+    hre: HardhatRuntimeEnvironment
+) => {
+    const signer = await hre.ethers.getNamedSigner('deployer')
+    // @ts-expect-error ignore for example
+    const token = (await hre.ethers.getContract(contractName)).connect(signer)
+
+    const amountLD = BigNumber.from(amount)
+    const sendParam = {
+        dstEid,
+        to: makeBytes32(to),
+        amountLD: amountLD.toString(),
+        minAmountLD: amountLD.mul(9_000).div(10_000).toString(),
+        extraOptions: '0x',
+        composeMsg: '0x',
+        oftCmd: '0x',
+    }
+    const [msgFee] = await token.functions.quoteSend(sendParam, false)
+    const txResponse = await token.functions.send(sendParam, msgFee, signer.address, {
+        value: msgFee.nativeFee,
+        gasLimit: 500_000,
+    })
+    const txReceipt = await txResponse.wait()
+    console.log(`send: ${amount} to ${to}: ${txReceipt.transactionHash}`)
+    console.log(
+        `Track cross-chain transfer here: ${getLayerZeroScanLink(
+            txReceipt.transactionHash,
+            dstEid == EndpointId.SOLANA_V2_TESTNET
+        )}`
+    )
+}
+
+task('send', 'Sends a transaction', action)
+    .addParam('dstEid', 'Destination endpoint ID', undefined, types.int, false)
+    .addParam('amount', 'Amount to send in wei', undefined, types.string, false)
+    .addParam('to', 'Recipient address', undefined, types.string, false)
+    .addOptionalParam('contractName', 'Name of the contract in deployments folder', 'MyOFT', types.string)

--- a/examples/oft/tasks/index.ts
+++ b/examples/oft/tasks/index.ts
@@ -1,0 +1,1 @@
+import './evm/send'


### PR DESCRIPTION
## Summary
- enable custom Hardhat tasks in OFT examples
- add `send` task for EVM tokens

## Testing
- `pnpm test` *(fails: command `pnpm run compile` exited with code 1)*